### PR TITLE
Add proxyPath and extraEnv support, code tidying

### DIFF
--- a/charts/redisinsight/Chart.yaml
+++ b/charts/redisinsight/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.5
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.28.0"
+appVersion: "2.48.0"
 
 icon: https://avatars.githubusercontent.com/u/87389211
 

--- a/charts/redisinsight/templates/deployment.yaml
+++ b/charts/redisinsight/templates/deployment.yaml
@@ -29,38 +29,48 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes:
         - name: redisinsight
-{{ if .Values.persistentVolumeClaim.create }}
+          {{- if .Values.persistentVolumeClaim.create }}
           persistentVolumeClaim:
             claimName: {{ include "redisinsight-chart.fullname" . }}-data
-{{ else }}
+          {{- else }}
           emptyDir: {}
-{{ end }}
+          {{- end }}
       containers:
-        - env:
-            - name: RILOGLEVEL
-              value: DEBUG
-            - name: RITRUSTEDORIGINS
-              value: {{ .Values.trustedOrigins }}
-            - name: APP_FOLDER_ABSOLUTE_PATH
-              value: {{ .Values.volumeMount.mountPath }}
-          name: {{ .Chart.Name }}
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+        - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: RI_LOG_LEVEL
+              value: "{{ .Values.redisinsight.logLevel }}"
+            - name: RI_FILES_LOGGER
+              value: "false"
+            - name: RI_STDOUT_LOGGER
+              value: "true"
+            {{- if .Values.redisinsight.proxyPath }}
+            - name: RI_PROXY_PATH
+              value: "{{ .Values.redisinsight.proxyPath }}"
+            {{- end}}
+          {{- if gt (len .Values.extraEnv) 0 }}
+          {{- .Values.extraEnv | toYaml | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
-            {{- toYaml .Values.livenessProbe | nindent 12 }}
+            {{- $httpPath := fromJson (tpl "{ \"httpGet\": { \"path\": \"{{ .Values.redisinsight.proxyPath }}{{ .Values.livenessProbeDefault.httpGet.path }}\" }}" .) }}
+            {{- toYaml (merge .Values.livenessProbe $httpPath .Values.livenessProbeDefault) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
-            {{- toYaml .Values.readinessProbe | nindent 12 }}
+            {{- $httpPath := fromJson (tpl "{ \"httpGet\": { \"path\": \"{{ .Values.redisinsight.proxyPath }}{{ .Values.readinessProbeDefault.httpGet.path }}\" }}" .) }}
+            {{- toYaml (merge .Values.readinessProbe $httpPath .Values.readinessProbeDefault) | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          volumeMounts:
-            - name: redisinsight
-              mountPath: {{ .Values.volumeMount.mountPath }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/redisinsight/values.yaml
+++ b/charts/redisinsight/values.yaml
@@ -10,10 +10,10 @@ fullnameOverride: ""
 replicaCount: 1
 
 image:
-  repository: heywood8/redisinsight
+  repository: redis/redisinsight
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "2.48.0"
 
 # Set imagePullSecret if you use image from private repository
 imagePullSecrets: []
@@ -46,7 +46,7 @@ securityContext:
 
 service:
   type: ClusterIP
-  port: 5000
+  port: 5540
 
 ingress:
   enabled: false
@@ -91,15 +91,40 @@ volumeMount:
   # Set to /db/ for redisinsight versions < 2
   mountPath: /redisinsight/
 
-livenessProbe:
-  tcpSocket:
+livenessProbeDefault:
+  httpGet:
+    path: /api/health
     port: http
   periodSeconds: 10
   failureThreshold: 2
+livenessProbe:
+  enabled: true
 
-readinessProbe:
-  tcpSocket:
+readinessProbeDefault:
+  httpGet:
+    path: /api/health
     port: http
   initialDelaySeconds: 15
   periodSeconds: 10
   failureThreshold: 2
+readinessProbe:
+  enabled: true
+
+extraEnv: []
+# - name: VAR_NAME
+#   value: var_value
+# - name: VAR_NAME_FROM_CONFIGMAP
+#   valueFrom:
+#     configMapKeyRef:
+#       name: redisinsight
+#       key: email
+
+envFrom: [] # not supported yet
+# - type: secret
+#   name: redisinsight-secret
+# - type: configMap
+#   name: redisinsight-cm
+
+redisinsight:
+  logLevel: info
+  proxyPath: ""

--- a/charts/redisinsight/values.yaml
+++ b/charts/redisinsight/values.yaml
@@ -13,7 +13,7 @@ image:
   repository: redis/redisinsight
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "2.48.0"
+  tag: ""
 
 # Set imagePullSecret if you use image from private repository
 imagePullSecrets: []


### PR DESCRIPTION
I have:
- changed image to RedisInsight official one
- updated version to 2.48.0
- updated `env` to reflect present version configuration
- added `extraEnv` support to configure app
- added `proxyPath` support - to change path under which application is served - sets `RI_PROXY_PATH` env variable and updates `livenessProbe` to `readinessProbe` path